### PR TITLE
feat: improve sidebar labels and pagination

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,8 +14,22 @@ export default defineConfig({
         { icon: 'cloud-download', label: 'Website', href: 'https://webilia.com' },
       ],
       sidebar: [
-        { label: 'Listdom', autogenerate: { directory: 'listdom' } },
-        { label: 'Vertex Addons', autogenerate: { directory: 'vertex' } },
+        {
+          label: 'Listdom',
+          items: [
+            { label: 'Overview', link: '/listdom/' },
+            { label: 'Getting Started', autogenerate: { directory: 'listdom/getting-started' } },
+          ],
+        },
+        {
+          label: 'Vertex Addons',
+          items: [
+            { label: 'Overview', link: '/vertex/' },
+            { label: 'Getting Started', autogenerate: { directory: 'vertex/getting-started' } },
+            { label: 'Extensions', autogenerate: { directory: 'vertex/extensions' } },
+            { label: 'Widgets', autogenerate: { directory: 'vertex/widgets' } },
+          ],
+        },
       ],
       plugins: [
         starlightUtils({ multiSidebar: { switcherStyle: 'horizontalList' } }),

--- a/src/content/docs/listdom/getting-started/installation.mdx
+++ b/src/content/docs/listdom/getting-started/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Installation
 description: Install Listdom to start building your directory.
+next: false
 ---
 
 Follow these steps to install Listdom on your WordPress site.

--- a/src/content/docs/vertex/index.mdx
+++ b/src/content/docs/vertex/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Overview
 description: Vertex Addons extends Elementor with advanced widgets and design options.
+prev: false
 ---
 
 Vertex Addons enhances the Elementor page builder by adding a collection of widgets and customization controls to build engaging, responsive websites.


### PR DESCRIPTION
## Summary
- make sidebar directory names human friendly
- hide prev/next pagination between Listdom and Vertex

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_689e73056bd8832cb4ebfa2843e8712e