### PR TITLE
feat: add multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Welcome! This repository contains the source code for the documentation of Webil
 
 If you are an end user looking for product documentation or reference material, please visit [docs.webilia.com](https://docs.webilia.com). The website hosts the latest documentation for all of our products.
 
+The site now provides multilingual support and can be browsed in English, French, and Spanish.
+
 ## Contributing
 
 We appreciate help from the community. If you find an error or have suggestions to improve the documentation, feel free to fork this repository and open a pull request.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,12 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Webilia',
+      defaultLocale: 'en',
+      locales: {
+        en: { label: 'English' },
+        fr: { label: 'Français' },
+        es: { label: 'Español' },
+      },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/webilia/docs' },
         { icon: 'linkedin', label: 'LinkedIn', href: 'https://www.linkedin.com/in/webilia-inc/' },

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Bienvenido a Webilia
+description: Aprende sobre los productos de Webilia.
+template: splash
+hero:
+  tagline: Bienvenido a Webilia
+  image:
+    file: ../../../assets/houston.webp
+  actions:
+    - text: Listdom
+      link: /listdom
+      icon: right-arrow
+    - text: Vertex Addons
+      link: /vertex
+      icon: right-arrow
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Próximos pasos
+
+<CardGrid stagger>
+        <Card title="Actualizar contenido" icon="pencil">
+                Edite `src/content/docs/index.mdx` para ver cambiar esta página.
+        </Card>
+        <Card title="Agregar nuevo contenido" icon="add-document">
+                Agregue archivos Markdown o MDX a `src/content/docs` para crear nuevas páginas.
+        </Card>
+        <Card title="Configurar su sitio" icon="setting">
+                Edite su `sidebar` y otra configuración en `astro.config.mjs`.
+        </Card>
+        <Card title="Leer la documentación" icon="open-book">
+                Aprenda más en [la documentación de Starlight](https://starlight.astro.build/).
+        </Card>
+</CardGrid>

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -1,0 +1,35 @@
+---
+title: Bienvenue chez Webilia
+description: Découvrez les produits Webilia.
+template: splash
+hero:
+  tagline: Bienvenue chez Webilia
+  image:
+    file: ../../../assets/houston.webp
+  actions:
+    - text: Listdom
+      link: /listdom
+      icon: right-arrow
+    - text: Vertex Addons
+      link: /vertex
+      icon: right-arrow
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Prochaines étapes
+
+<CardGrid stagger>
+        <Card title="Mettre à jour le contenu" icon="pencil">
+                Modifiez `src/content/docs/index.mdx` pour voir cette page changer.
+        </Card>
+        <Card title="Ajouter du nouveau contenu" icon="add-document">
+                Ajoutez des fichiers Markdown ou MDX à `src/content/docs` pour créer de nouvelles pages.
+        </Card>
+        <Card title="Configurer votre site" icon="setting">
+                Modifiez votre `sidebar` et d'autres paramètres dans `astro.config.mjs`.
+        </Card>
+        <Card title="Lire la documentation" icon="open-book">
+                En savoir plus dans [la documentation Starlight](https://starlight.astro.build/).
+        </Card>
+</CardGrid>


### PR DESCRIPTION
## Summary
- enable English, French, and Spanish locales in docs configuration
- add French and Spanish translations for the home page
- document multilingual support in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e8b8ed7b8832c838e5be750e53dce