### PR TITLE
Fix English default locale routing and local home links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,9 +8,9 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Webilia',
-      defaultLocale: 'en',
+      defaultLocale: 'root',
       locales: {
-        en: { label: 'English' },
+        root: { label: 'English', lang: 'en' },
         fr: { label: 'Français' },
         es: { label: 'Español' },
       },

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -8,10 +8,10 @@ hero:
     file: ../../../assets/houston.webp
   actions:
     - text: Listdom
-      link: /listdom
+      link: /es/listdom
       icon: right-arrow
     - text: Vertex Addons
-      link: /vertex
+      link: /es/vertex
       icon: right-arrow
 ---
 

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -8,10 +8,10 @@ hero:
     file: ../../../assets/houston.webp
   actions:
     - text: Listdom
-      link: /listdom
+      link: /fr/listdom
       icon: right-arrow
     - text: Vertex Addons
-      link: /vertex
+      link: /fr/vertex
       icon: right-arrow
 ---
 


### PR DESCRIPTION
## Summary
- remove `/en` prefix by setting English locale as root
- update French and Spanish home links to point to localized product pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e951a21f4832c8926ed73790c4706