### PR TITLE
chore: remove webilia link from header

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,7 +27,6 @@ export default defineConfig({
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/webilia/docs' },
         { icon: 'linkedin', label: 'LinkedIn', href: 'https://www.linkedin.com/in/webilia-inc/' },
-        { icon: 'cloud-download', label: 'Website', href: 'https://webilia.com' },
       ],
       sidebar: [
         {


### PR DESCRIPTION
## Summary
- remove `https://webilia.com` link from docs header social links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ebd1af3a0832c86f27f5f93ffcf3d