### PR TITLE
docs: expand template builder and advanced features

### DIFF
--- a/src/content/docs/vertex/advanced-features/advanced-popup-builder.mdx
+++ b/src/content/docs/vertex/advanced-features/advanced-popup-builder.mdx
@@ -1,8 +1,79 @@
 ---
-title: Advanced Popup Builder
-description: TODO
+title: Popup Builder
+description: "Create and manage popups in Elementor with Vertex’s Advanced Popup Builder – design modals and set when/where they appear."
 sidebar:
   order: 2
 ---
+import { Aside, Steps, Badge } from '@astrojs/starlight/components';
 
-Content coming soon.
+Vertex Addons includes an Advanced Popup Builder, enabling you to design popups in Elementor and display them on your site with specific triggers and conditions. This feature lets you create things like newsletter signups, announcements, or any modal content with full control over styling – similar to Elementor Pro’s Popup feature, but available to you in the free plugin.
+
+## Creating a Popup
+<Steps>
+1. **Navigate to Popups:** In WordPress admin, go to Vertex Addons > Popup. (You’ll find “Popup” under the main Vertex Addons menu.)
+2. **Add New Popup:** Click “New Popup” (the Add New button). A dialog will prompt for a popup name. Give it a descriptive name (e.g., “Newsletter Signup Popup” – this is internal, for your reference).
+3. **Create Popup Template:** Submit the dialog. Vertex will create the popup template and open it in the Elementor editor for you.
+4. **Design the Popup Content:** Now you’re in Elementor editing a blank popup canvas. Design the content of your popup just like a section:
+   - You might set a background color or image for the popup container (to make it eye-catching or match your branding).
+   - Add your content: for example, a Heading (“Subscribe to Our Newsletter”), some text, an Elementor Form (if you have a form widget/plugin) or an email field, an image, a call-to-action button, etc. You have complete freedom – treat it like designing a mini-page that will appear in a modal.
+   - Keep in mind popups usually should be concise and focused (space is limited).
+5. **Configure Popup Settings:** Vertex adds special settings for the popup:
+   - In the editor’s sidebar, click the gear icon (bottom left) to access Popup Settings (Document settings for the popup). Under Display Settings:
+     - Open Event: Choose how the popup should trigger:
+       - “On Page Load” – the popup will automatically appear when the page loads. If selected, also set Open Delay (Sec) – e.g., enter “5” for a 5-second delay after page load.
+       - “On Exit” – the popup will appear when the user’s mouse leaves the viewport (an attempt to exit).
+       - “Not Selected” – no automatic trigger (you might trigger this popup manually or via custom link).
+     - Show Once: Toggle this on (Yes) if you want the popup to only show once per user (per browser). This uses local storage – if a user has seen it, it won’t show again on subsequent page loads.
+     - Close on ESC: Leave this on (Yes) to allow users to press the Escape key to close the popup.
+     - Disable Page Scrolling: If set to Yes, when the popup is open, the page behind it won’t scroll (useful to focus attention on the popup).
+     - Overlay Click – Close: Ensure the overlay click close is enabled (so if user clicks outside the popup, it closes) unless you specifically want them to only use a close button.
+     - You can also find style settings for the overlay and close button in the editor (for example, under Style tab > Overlay, Style tab > Close Button). Here you can adjust the background overlay color/transparency and the appearance/position of the close “X” button.
+   - Display Conditions for Popup: Still in Popup Settings, set where this popup should appear:
+     - You might want it on the entire site (common for a newsletter or announcement). In Display Conditions (likely under the Advanced tab since popups use similar condition interface), enable conditions and choose Entire Site if so.
+     - Or target specific pages: e.g., show on Homepage only, or on Posts only, etc. You have the same condition options as templates (Entire site, singular, archive, etc.). Select what makes sense.
+6. **Publish the Popup:** Click Publish. Confirm any conditions prompt. Now the popup is saved and active on your site.
+</Steps>
+
+## Testing and Using the Popup
+
+Once published, visit a page that meets your display condition:
+
+If you set “Entire Site” and trigger on page load with a delay, then after the specified seconds on any page, the popup should fade in.
+
+If set to trigger on exit intent, try moving your mouse toward the top of the browser window – the popup should appear.
+
+If no automatic trigger was set (Open Event “Not Selected”), the popup won’t appear on its own. In that case, you’d need a manual trigger (for example, a button on your site that on click opens the popup). To do this manually, you can give an element an ID or class and use a bit of script, but Vertex’s UI doesn’t provide direct “on click” triggers in free version. (Advanced users could trigger by linking to the popup’s ID anchor or using custom JS.)
+
+Check the popup’s appearance:
+
+The overlay (dim background behind the popup) should cover the page.
+
+Your content should be centered (by default, Vertex centers the popup).
+
+The close button (×) is visible (usually top-right of popup).
+
+Try closing: clicking outside or on the close button should close it smoothly. Also pressing ESC if that option is on.
+
+If the popup doesn’t show:
+
+Re-check the trigger settings (Open Event). If on load with delay, did you wait long enough? If on exit, it only triggers when cursor leaves viewport (desktop only).
+
+Ensure the page you’re on matches the Display Condition.
+
+If multiple popups exist with overlapping conditions, note they can all trigger (they would queue or overlap, which is typically not desired). It’s best to have distinct conditions or use the Show Once setting to avoid bombardment.
+
+## Tips for Effective Popups
+
+Size and Position: The popup container width can be adjusted in the Popup settings under Layout (e.g., you can set a specific width or height, or keep it auto). Typically let it be a reasonable width (maybe 400-600px) so it doesn’t overwhelm.
+
+Design for Attention: Use clear messaging and a strong call-to-action. Since you have Elementor, you can include images, icons, etc., for impact.
+
+Frequency: If using a site-wide popup on load, consider using Show Once <Badge text="Pro" /> (or the provided toggle) so users don’t see it repeatedly. Nothing frustrates users more than the same popup on every page refresh. By default, Vertex’s “Show once” will ensure each visitor sees it only the first time.
+
+Multiple Popups: You can create different popups for different purposes. For example, one for a promotion that only shows on a specific landing page, another as an exit intent on pricing pages. Leverage Display Conditions to target them precisely.
+
+Manual Triggers (Optional Advanced): If you want a popup to open on a button click, leave its Open Event as Not Selected (so it doesn’t auto-open). Then give your button a unique selector and use a script to open the popup by adding the class afeb-popup-open to the popup’s container (requires custom code). This is advanced; if you’re not comfortable with code, you might stick to the built-in triggers (load/exit).
+
+<Aside type="note">The Popup Builder even allows using dynamic content inside the popup. For example, you could create a popup that shows a Post Title and Post Content – then, using dynamic conditions, you could potentially trigger it for specific posts. In most cases though, popups are used for static promotional content or forms, not dynamic post content.</Aside>
+
+By using Vertex’s Popup Builder, you can enhance user engagement on your site – from announcing sales to capturing leads – all using Elementor’s visual design tools. Design popups that match your site’s style and set them to appear at just the right moment to catch your visitors’ attention.

--- a/src/content/docs/vertex/advanced-features/dynamic-tags.mdx
+++ b/src/content/docs/vertex/advanced-features/dynamic-tags.mdx
@@ -1,8 +1,112 @@
 ---
 title: Dynamic Tags
-description: TODO
+description: "Leverage Vertex’s Dynamic Tags to insert post data and site information (title, dates, author, etc.) into Elementor designs dynamically."
 sidebar:
   order: 4
 ---
+import { Aside } from '@astrojs/starlight/components';
 
-Content coming soon.
+Dynamic Tags allow you to inject dynamic content (like post titles, dates, custom URLs, etc.) into Elementor elements. Vertex Addons provides a range of Dynamic Tags that are normally only available with Elementor Pro, enabling you to build more dynamic, data-driven designs with Elementor Free.
+
+## What are Dynamic Tags?
+
+In Elementor, when editing a widget (say a Heading or a Text field), you’ll see a small database icon next to many input fields. That icon means you can select a dynamic value for that field instead of static text. Dynamic Tags are those values – they pull content from your site or the current page context.
+
+Vertex adds new tags such as Post Title, Post Excerpt, Post Content, Post Date, Post Terms, Author Info, Site URL, Internal URL, and more. These tags update automatically based on the content being viewed.
+
+For example:
+
+Using the Post Title tag in a Heading widget on a Single Post Template will display the actual title of each post.
+
+An Internal URL tag can be used to link a button to a specific page without hardcoding the URL (useful if the URL might change, it stays updated).
+
+## Available Dynamic Tags in Vertex
+
+Vertex introduces several categories of tags:
+
+Post Tags: These retrieve information about the current post (or page):
+
+Post Title – The title of the post.
+
+Post Excerpt – The excerpt (summary) of the post.
+
+Post Content – The full content/body of the post (use carefully, typically used in the Post Content widget rather than inline).
+
+Post Date – The publish date of the post. (Vertex lets you choose the date format in the tag’s settings, e.g., June 1, 2025 or 2025-06-01.)
+
+Post Time – The publish time of the post (selectable format, or combined date/time if needed).
+
+Post URL – The permalink URL of the post. Useful for linking buttons or read more links.
+
+Post Terms – The categories or tags assigned to the post. You can select which taxonomy (category, tag, or any custom taxonomy) and the tag will output them (with optional separators and link on/off).
+
+Post Featured Image – (Appears in image fields) The featured image of the post; you can use this to dynamically set an Image widget’s source.
+
+Post Comments – The number of comments text. This tag can output “No Comments”, “1 Comment”, or “X Comments” based on settings.
+
+Author Tags: These provide info about the author of the current post:
+
+Author Name – The display name of the post’s author.
+
+Author URL – A link to the author’s archive page (if you link text to this tag, clicking it would go to all posts by that author).
+For an author bio or avatar, Vertex has an Author Box widget, but dynamic tags cover basic author text data.
+
+Archive Tags: (Useful in Archive Templates)
+
+Archive Title – The title of the current archive page. For example “Category: News” or “Search Results for X”.
+
+Archive Description – The description of the current archive (e.g., a category description text, if it exists).
+
+Site Tags:
+
+Site URL – The home URL of your site. This is handy if you need to link something back to the homepage dynamically.
+
+Internal URL – This special tag allows you to select any internal content and outputs its URL. When you choose this tag, you can select Type (Post, Page) and then pick a specific post or page. It will then dynamically use that page’s URL. For example, link a button to a certain page – if that page URL changes, the tag updates automatically.
+
+Site Title – Not explicitly listed as a tag in Vertex’s code from what we saw, but you might use the Site Title widget instead. (If provided, it would output your site’s name.)
+
+Miscellaneous: If any additional dynamic tags are added by Vertex (for instance, it might include things like current user info or other internal data), you would find them in the dynamic tag list with an “Addon” label.
+
+All these tags are accessible by clicking the dynamic icon (database icon) next to a field and looking under sections likely labeled by content type (Elementor might group them by “Site”, “Post”, etc., and Vertex’s tags may appear under those or under a “Vertex” or “AFEB” section).
+
+## Using Dynamic Tags
+
+In Text or Heading Widgets: Instead of typing static text, click the dynamic icon. Choose (for example) Post Title. The field will show a placeholder indicating a dynamic tag is set. On the live page, it will output the actual post’s title.
+
+Link Fields: You can make a button link dynamic. For instance, select Internal URL tag, then choose a page (like “Contact Us”) in the tag settings. Now that button will always link to your Contact page – if you ever change the page’s URL or replace the page, updating the tag settings will update all such buttons.
+
+Images: Add an Image widget, click the dynamic icon for the image source, choose Post Featured Image. Now the image will show the current post’s featured image. You can even set fallback images in tag settings if needed.
+
+Repeating Elements: In a Loop Item Template or Archive, these tags shine – e.g., using Post Title tag means each item shows its own title.
+
+Vertex’s dynamic tags can be combined with Elementor Free’s features to achieve dynamic designs that were previously only possible with Pro:
+
+Want a post’s publish date in a fancy format below the title? Use a Text widget, type “Published on ” and then insert the Post Date tag after it (you can mix static text and dynamic in one text widget by using multiple tags).
+
+Need a “Read more” text that is clickable to the post? You could drop a Text Editor, write “Read more”, select it, add a hyperlink, and for the URL choose Post URL dynamic tag.
+
+## Dynamic Tag Settings
+
+Many tags have simple options:
+
+Date/Time tags let you pick the format (like F j, Y for a full date).
+
+Post Terms tag lets you pick taxonomy (category, tag) and a separator (e.g., comma).
+
+Internal URL tag, as mentioned, lets you choose what link (post, page, etc.) it should output.
+
+These settings ensure the output appears exactly as you need.
+
+<Aside type="caution">Be mindful of context: Dynamic tags pull from the current post or page in view. If you use a Post Title tag on a normal page (not in a Loop or Single template), it will show that page’s title. In a header or footer (which are outside the loop context), some post tags might not output what you expect (for instance, Post Title used in a global header might show the title of the page currently being viewed – which could be useful or not depending on your design). Always test to ensure the dynamic content is appearing where and how you intend.</Aside>
+
+## Tips and Advanced Usage
+
+Combining Tags: You can place multiple dynamic tags in one widget (especially the Text Editor widget). For example: “Posted on Post Date by Author Name in Post Terms (Category)” – this could all be one text block with those tags inserted in the sentence.
+
+Site Identity: If Vertex doesn’t have a Site Title tag, remember there is a Site Title widget you can use in headers to dynamically show the site name (and a Site Logo widget for the logo).
+
+Updates: Dynamic tags always fetch the current data. Change a post’s title, and anywhere a Post Title tag was used (like on the homepage featured post section) it updates automatically. This reduces manual maintenance.
+
+Custom Fields (Pro): If you have custom fields (ACF, etc.), Vertex’s free dynamic tags might not cover those. That typically requires Elementor Pro or a separate addon. Vertex Pro might introduce dynamic tags for custom fields in the future. For now, the included tags cover the standard WordPress data.
+
+Using dynamic tags makes your Elementor designs smarter – the content displayed is always up-to-date and contextually relevant. It’s a key part of building templates (headers, singles, etc.), but even in static pages you can use them for consistency (like an automatically updating year, or pulling in a specific post title somewhere). Explore the dynamic tag menu and see what data you can harness for a more dynamic site experience.

--- a/src/content/docs/vertex/advanced-features/templates-kit-demo-importer.mdx
+++ b/src/content/docs/vertex/advanced-features/templates-kit-demo-importer.mdx
@@ -1,8 +1,80 @@
 ---
-title: Templates Kit Demo Importer
-description: TODO
+title: Template Kit Importer
+description: "Quickly import pre-designed website template kits with Vertex Addons’ Template Kit feature to jumpstart your site design."
 sidebar:
   order: 1
 ---
+import { Aside, Steps, Badge } from '@astrojs/starlight/components';
 
-Content coming soon.
+Vertex Addons includes a Template Kit Demo Importer that lets you import complete packs of templates (pages, header, footer, etc.) for a given website design. In one go, you can set up a ready-made site design and then customize content to your needs. This is great for getting a head start on a new website.
+
+## What is a Template Kit?
+
+A Template Kit is a collection of Elementor templates assembled to create a full website layout. It typically includes a home page, about page, contact page, header, footer, blog archive, single post template, etc., all styled consistently. By importing a kit, you get all these pieces installed on your site.
+
+Vertex provides some template kits as demos. For example, a “Nonprofit Organization” kit might include multiple pages (Home, About, Contact, Blog, etc.) and the necessary header/footer and blog templates that match that design.
+
+## Importing a Template Kit
+<Steps>
+1. **Open Template Kit Importer:** In WordPress admin, navigate to Vertex Addons > Templates Kit. (This is a tab in the Vertex Addons menu).
+2. **Browse Available Kits:** You will see a gallery of template kits. Each kit might be represented by a thumbnail image and name/description. For example, you might find a kit like “Nonprofit Organization” with a short description of its style and included pages.
+3. **Preview (Optional):** If there’s a Preview option, click it to see details of the kit. Vertex may show previews of the pages included or a live demo link. This helps you decide if the kit suits your needs.
+4. **Import the Kit:** Click the Import button on the kit you want. A confirmation dialog may appear, summarizing what will happen. (The importer will add pages/templates to your site. If required plugins are needed, it may prompt or attempt to install them – e.g., if a kit uses a form widget from a certain plugin.)
+5. **Confirmation:** Confirm to proceed. The import process will begin. You might see a progress indicator. Vertex will:
+   - Download the kit’s template files from the cloud.
+   - Import all the templates (pages, section templates, theme builder parts like header/footer).
+   - Import site settings if the kit defines global styles.
+   - Activate any required plugins listed for the kit (the importer might install and activate dependencies automatically for you if needed).
+   - Assign the imported templates appropriately (e.g., set the imported header as the active header template, assign the imported homepage as your Front Page in WordPress settings, etc.).
+   - Completion: Wait for the import to finish. You should get a success message once done (e.g., “Template Kit imported successfully!”).
+</Steps>
+
+## After Import – Setting Up
+
+Once the kit is imported:
+
+Pages Added: Check Pages > All Pages in your dashboard. You will find new pages like Home, About Us, Contact, etc., created by the kit. They will be populated with demo content.
+
+Templates Added: Under Vertex Addons > Template Builder, you’ll see new templates (Header, Footer, Single, Archive) that were part of the kit. These are already published and assigned via conditions (the kit import handles that).
+
+Site Settings: Some kits may adjust your Reading Settings (setting the home page to the imported Home, and blog page to a Blog page). Verify under Settings > Reading that your homepage is set to the intended page if applicable.
+
+Menus: If the kit included menus, you might need to assign menus to theme locations. For example, check Appearance > Menus – a menu might be imported, but you should assign it to the Primary menu location (especially if using Vertex’s header, ensure the Nav Menu widget in the header is pointed to this menu).
+
+Widgets/Plugins: If a kit uses specific widgets (like a form or slider), ensure those plugins are installed. The importer often takes care of this. For instance, if the kit had a form built with Elementor Pro, Vertex would typically avoid that in a free kit, but if so, you might need Elementor Pro or replace that form with a free alternative.
+
+Now visit your site’s homepage (which should now be the kit’s home design):
+
+You’ll see a fully designed page with placeholder text and images from the kit.
+
+The header and footer should reflect the kit’s style.
+
+Navigate to other imported pages to review their design.
+
+## Customizing the Imported Kit
+
+The power of template kits is that after importing:
+
+Replace Content: Edit each imported page with Elementor to replace text and images with your own content. The design (layout, colors, typography) is already there; you just swap out the placeholder content.
+
+Global Styling: The kit likely applied consistent colors and fonts via Elementor’s Site Settings or global styles. You can tweak these globally if you want to adjust the theme of the kit (for instance, change the primary color in one place, rather than on each widget).
+
+Update Templates: If the kit’s header has a logo placeholder, you’ll want to edit the Header template (via Template Builder or “Edit with Elementor” on the header template) and insert your site’s actual logo (e.g., using the Site Logo widget which will pull from your site identity, or directly replacing the image).
+
+Similarly, check the Footer template for any placeholder address or social links and update them.
+
+Review Dynamic parts: If the kit included a Blog Single template or Archive, make sure they function with your actual posts (the demo content might include some dummy posts). Create or use existing posts to ensure the single post template displays properly.
+
+<Aside type="tip">It’s good practice after importing a kit to go through each page and template systematically to personalize it. The Template Kit gives you a huge head start with design, but it’s your content and branding that will make it truly yours. Replace all instance of demo text (“Lorem ipsum”) and images to avoid an unprofessional look.</Aside>
+
+## Important Notes
+
+Images in Kits: Demo images are often copyright or low-resolution placeholders. Template Kit imports might include these images for layout purposes. Plan to replace them with your own licensed images. The kit’s images are usually just for demonstration.
+
+Multiple Imports: You can import multiple kits, but it’s generally not recommended to mix entire kits on one site as they have different design languages. If you do import another kit, be aware it will add more pages and could overwrite some settings. It’s usually best to stick to one kit and customize it.
+
+Cleanup: If you decide a kit isn’t to your liking after import, you may need to manually delete the imported pages and templates. (There isn’t an automatic “uninstall kit” feature, so be mindful before importing.)
+
+<Aside type="note">Vertex Addons <Badge text="Pro" /> users may have access to a larger library of Template Kits and possibly the ability to import premium designs. The process remains the same. Using kits can save hours of design time by providing a complete starting point that you then tweak.</Aside>
+
+By utilizing the Template Kit importer, even beginners can set up a complex website layout in minutes. It’s like having a blueprint of a house ready – all you do is move in your furniture (content). This accelerates development while still allowing full customization via Elementor for truly bespoke results.

--- a/src/content/docs/vertex/template-builder/archive.mdx
+++ b/src/content/docs/vertex/template-builder/archive.mdx
@@ -1,8 +1,62 @@
 ---
-title: Archive
-description: TODO
+title: Archive Template
+description: "Design custom archive pages (blog listings, categories, search results) with Vertex’s Archive Template feature."
 sidebar:
   order: 3
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Archive pages (like your blog index, category listings, tags, or search results) display lists of posts. With Vertex Addons, you can create a Custom Archive Template to control the layout and style of these pages. Instead of relying on your theme’s archive design, you’ll design it in Elementor, choosing exactly how posts should be presented.
+
+{/* Image for archive template editing screen */}
+
+## Creating an Archive Template
+<Steps>
+1. **Add New Archive Template:** Go to Vertex Addons > Template Builder and click “New Template”. In the dialog, choose Archive as the template type. Give it a name like “Blog Archive” or “Search Results Template” (optional) and create it.
+2. **Design in Elementor:** The new archive template will open in Elementor editor. Now design how you want your archive pages to look:
+   - Archive Title: Use the Archive Title widget (provided by Vertex) to dynamically show the title of the archive (e.g., “Category: News” or “Search Results for…”). This widget will output the context-specific title automatically.
+   - Posts Listing: To display the list of posts for the archive, drag in a Dynamic Archive Posts widget (Vertex). This widget is specifically made for archive templates – it will automatically pull the posts from the current archive (category, search query, etc.) and display them. By default, it might show a simple list; you can customize it.
+   - Customize Post Appearance: The Dynamic Archive Posts widget can be customized in two ways:
+     - Basic Settings: Choose layout (grid or list, number of columns, pagination, etc.).
+     - Loop Item Template: For more advanced design, Vertex lets you select a Dynamic Loop Item template within this widget (the setting “Choose a template”). If you have created a Dynamic Loop Item template (for post cards), select it to style each post item. Otherwise, the widget will display posts in a default style.
+   - Additional Elements: You might add other widgets like an Archive Description (if you want to show category description text – available via dynamic tag or an Elementor widget if provided), a search bar at top, or filters (some advanced design).
+   - Design the overall page structure – for instance, you could include a sidebar by using Elementor’s columns, or a full-width layout with a grid of posts.
+   - Responsive Design: Check tablet and mobile views in Elementor. Ensure the post grid/list is legible on smaller screens (adjust columns or switch to a single column on mobile if using a grid).
+3. **Set Display Conditions:** In the template’s settings (Elementor panel), set where this archive template applies. Under Display Conditions:
+   - Typically, you might choose All Archives to apply to every archive page (this covers blog, categories, tags, etc.).
+   - If you want to target specific archives, you can. For example, you can set condition for a particular category archive only, or choose Archive -> Posts Archive (blog index) specifically. Vertex allows multiple archive templates if you need different designs per archive type.
+   - Common setting: For a general blog design, select Posts Archive (this covers the main blog listing). For categories/tags, you could either make one template for all, or separate if desired.
+   - (If unsure, selecting the broad “Archive – All” ensures all archive pages use this template.)
+4. **Publish:** Click Publish and confirm the conditions. Now the archive template is live.
+
+</Steps>
+
+## Checking the Archive Template on Your Site
+
+Once published, navigate to an archive on your site to see the result:
+
+Go to your blog page or a known category page. It should now display with the structure you built (the archive title, the styled list of posts, etc.).
+
+Verify that the Archive Title is showing the correct context (e.g., the category name or search term).
+
+Scroll through the post listings to ensure they appear as intended. If you used a Dynamic Loop Item template for the posts, confirm that design is applied to each item.
+
+If something is off:
+
+No posts showing? Ensure the Dynamic Archive Posts widget is present and configured. This widget by default takes the current query of the archive; you shouldn’t need to set a query for it when used in an Archive Template.
+
+Wrong template showing? Check Display Conditions. If multiple archive templates exist, a more specific one might override a general one. For instance, if you have one template assigned to “All Archives” and another specifically for “Search Results”, the search results page will use the specific one.
+
+Archive Title missing? Ensure you included the Archive Title widget, or add a heading with a dynamic tag for Archive Title.
+
+## Tips for Archive Templates
+
+Use Dynamic Content: Archive pages benefit from dynamic widgets. Besides Archive Title, you can also insert dynamic breadcrumbs (if you have a breadcrumb widget or plugin), or an Archive Description (Vertex’s dynamic tags include Archive Description which can be used in a Text widget).
+
+Pagination: The Dynamic Archive Posts widget will handle pagination if there are many posts. Style the pagination in the widget’s settings (it may have options for page numbers, next/prev text, etc.).
+
+Consistent Design: Typically, you’ll want archive pages to have the same header and footer as the rest of your site. By using Vertex’s Header and Footer templates in conjunction, your archive will seamlessly integrate with your site’s look.
+
+<Aside type="note">If you need a different layout for different archive types (say, a unique design for a specific category), you can create another Archive Template and set its condition to that category only. Vertex will use that for the chosen category while your default archive template covers the rest.</Aside>
+
+With a custom Archive Template in place, you control exactly how your blog listings and other archives appear. This helps in maintaining a branded, user-friendly blog section that matches your site’s design and showcases posts in the best way possible.

--- a/src/content/docs/vertex/template-builder/dynamic-loop-item.mdx
+++ b/src/content/docs/vertex/template-builder/dynamic-loop-item.mdx
@@ -1,8 +1,74 @@
 ---
-title: Dynamic Loop Item
-description: TODO
+title: Dynamic Loop Item Template
+description: "Design custom loop item templates to style repeated post listings (cards) and apply them in grids or carousels with Vertex."
 sidebar:
   order: 5
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Dynamic Loop Items are a unique feature in Vertex Addons that let you design how each item in a posts list or grid looks. Instead of a fixed design for post listings, you can create a Loop Item Template (essentially a mini-template for one post “card”), then use it in widgets like Dynamic Grid/Carousel or Archive Posts. This gives you complete control over the appearance of each post in a list.
+
+## What is a Dynamic Loop Item?
+
+A Dynamic Loop Item template is a small design that represents one post or item in a loop. For example, if you want your blog archive to show posts as cards with an image, title, and excerpt, you would create a loop item template that includes those elements arranged nicely. Then the posts widget will repeat that template for each post.
+
+This decouples the item design from the widget, allowing you to update the style of all post items in one place (the loop template). It’s similar to Elementor Pro’s Loop Grid feature, now available via Vertex.
+
+## Creating a Dynamic Loop Item Template
+<Steps>
+1. **Add New Loop Item Template:** Go to Vertex Addons > Template Builder and click “New Template.” In the dialog, select Dynamic Loop Item as the type. Name it something descriptive like “Post Card Template” (optional) and create it.
+2. **Design the Loop Item in Elementor:** The Elementor editor opens a blank canvas for your loop item. This canvas represents a single post item. Design it with the content that one item should display:
+   - Typically, a post “card” includes:
+     - A featured image,
+     - The post title,
+     - Maybe an excerpt or a short description,
+     - Perhaps metadata like date or category,
+     - A read more button or link.
+   - Featured Image: Drag the Post Featured Image widget into the design. This will dynamically pull in the post’s featured image for each item.
+   - Title: Add a Post Title widget (or a Heading and use dynamic tag for Post Title) to show the post’s title. Style it (font, size) as needed for a card.
+   - Excerpt: Insert the Post Excerpt widget if you want a snippet of the post content on the card. You can control excerpt length in that widget’s settings.
+   - Meta/Date: If you want the date or category on the card, you can include a Post Date widget (or dynamic Post Date tag in a Text element) and/or Post Terms widget for category tags.
+   - Read More: Optionally, add a Button or Text link for “Read More”. You can make this dynamic by linking it to the post’s URL. For example, set the button’s link to Post URL (use dynamic tag Post URL on the link field). Label the button “Read More” (or any call-to-action).
+   - Arrange these elements visually. You might have the image on top and text below, or image on left and text on right, depending on the look you want. It’s just like designing a small section in Elementor.
+   - Styling: Style each part to fit your site’s design. For instance, ensure the card has appropriate padding, maybe a background or border. You can also add a Hover effect on the card using Elementor interactions if desired.
+   - Responsive Check: Even though this is a small item, verify that it will display nicely in different grid arrangements. If your card is going to be in a 3-column grid on desktop and 1-column on mobile, ensure the design is flexible (Elementor typically will handle stacking, but check that nothing overflows or looks odd when narrower).
+   - No Display Conditions Needed: Loop Item templates are not directly assigned to pages via conditions. So you don’t set display conditions here. Instead, you will use this template within other widgets. (Vertex automatically knows this is a loop item design; it won’t appear on its own on the front-end by itself.)
+3. **Publish:** Click Publish to save the loop item template.
+
+</Steps>
+
+## Using the Loop Item Template in a Posts Widget
+
+Creating the template is only the first step. Now you apply it:
+
+Dynamic Grid/Carousel Widget: Edit a page (or an Archive Template) where you want to display a list of posts. Add the Dynamic Grid/Carousel widget (Vertex).
+
+In its settings, you’ll find an option “Choose a template” (or similar) which lists available Dynamic Loop Item templates. Select the name of the loop template you created (e.g., “Post Card Template”).
+
+Configure the query or source of posts. For example, if on a normal page, set it to show recent posts or posts by category. If you’re using it on an archive page, Vertex’s Dynamic Archive Posts widget is a variation that automatically pulls the archive’s posts – it also has a template selector.
+
+Set layout options like number of columns (the widget will repeat your loop item in each column), carousel settings if applicable, etc.
+
+Dynamic Archive Posts Widget: If you are in an Archive Template, you likely use this widget. It works similarly – ensure your loop item template is selected in the widget’s template option.
+
+Once set, the widget will render each post using your loop design:
+
+Each element (image, title, etc.) will populate with that post’s data.
+
+The styling and arrangement are exactly as you designed in the loop template.
+
+## Example Scenario
+
+Imagine you want a fancy blog grid:
+
+You made a loop item template that has a card with the post’s featured image as a background, title overlaid, and a read more button.
+
+On your Blog Archive Template, you insert Dynamic Archive Posts, choose a 3-column grid and select your loop template.
+
+When you view the blog page, you’ll see three posts per row, each rendered as that card design you built. Hover effects, fonts – all as set.
+
+If you ever want to change the look of those post cards, simply edit the Dynamic Loop Item template in Vertex and update it. All places where it’s used (grids, carousels, etc.) will automatically reflect the new design. This is incredibly efficient for site-wide updates to post listing styles.
+
+<Aside type="tip">You can create multiple loop item templates for different purposes. For instance, a compact list style vs. a card style. Then pick the appropriate one in each widget. This saves time if you want different looks in different sections (e.g., a sidebar recent posts list might use a simpler loop item template with just title and date).</Aside>
+
+Remember, a loop item template by itself does nothing until applied in a listing widget. It’s a design piece waiting to be utilized. Once you tie it to a Dynamic Posts widget, it becomes the blueprint for each item in that list.

--- a/src/content/docs/vertex/template-builder/footer.mdx
+++ b/src/content/docs/vertex/template-builder/footer.mdx
@@ -1,8 +1,51 @@
 ---
-title: Footer
-description: TODO
+title: Footer Template
+description: "Build a custom global footer for your site using Vertex’s Template Builder."
 sidebar:
   order: 2
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Custom footers allow you to define what appears at the bottom of your site. With Vertex’s Template Builder, you can design a Footer Template in Elementor and apply it site-wide or to specific pages. This replaces the theme’s footer with your own design, which can include widgets like copyright text, menus, social icons, etc.
+
+{/* Image for footer creation screen */}
+
+## Overview
+
+A Footer Template is a design for your site’s bottom section. Commonly, footers contain information like contact details, social media links, navigation menus, and copyright notices. By creating a footer with Vertex, you ensure these elements are consistent and easily editable in one place.
+
+<Aside type="tip">As with headers, using a minimal theme or disabling the default theme footer is recommended to avoid duplication. Vertex will inject your custom footer on pages matching the conditions you set, appearing at the bottom of the content.</Aside>
+
+## Creating a Footer Template
+<Steps>
+1. **Open Template Builder:** In the WordPress dashboard, navigate to Vertex Addons > Template Builder. Click “New Template” to create a new template.
+2. **Select Footer Type:** In the new template dialog, set the template Type to Footer. Optionally, give it a name (e.g., “Global Footer”) for easy identification.
+3. **Create and Launch Editor:** Click Create Template. Vertex will add the Footer template and open it in the Elementor editor.
+4. **Design Your Footer:** Using Elementor’s drag-and-drop:
+   - Add one or multiple sections that will form your footer layout. Typically, footers might have multiple columns for different content categories.
+   - Footer Content Ideas: You can use widgets such as Text Editor (for address or copyright text), Nav Menu (for secondary menu or quick links), Social Icons (for social media links), Site Logo (to display logo in footer), Contact Info widgets, etc.
+   - Style the footer with appropriate background color, padding, and typography to distinguish it from the main content.
+   - Dynamic Year or Site Info: If you want dynamic content like the current year in your copyright, you can use Elementor’s dynamic tags (Vertex includes a Post Date tag which could be repurposed for year, or simply update manually each year).
+   - Responsive Checks: Ensure the footer looks good on tablets and phones. Adjust column stacking or font sizes in Elementor’s responsive mode as needed.
+5. **Set Display Conditions:** In the editor’s settings for the template, locate Display Conditions. Enable it and specify where to display the footer. For a universal footer, choose Entire Site. You can also target specific sections (e.g., only blog pages, or exclude certain landing pages if needed).
+6. **Publish:** Click Publish. If prompted, confirm your display condition settings. Your footer template is now live.
+
+</Steps>
+
+## Verifying and Managing the Footer
+
+After publishing, load a page on your site to confirm that your new footer appears at the bottom. The custom footer will replace the theme’s footer for any page that meets the condition you set. Scroll down to see your design and ensure everything displays correctly.
+
+If the footer isn’t appearing:
+
+Check that the template is published (status is Published).
+
+Revisit Display Conditions to ensure the page you’re viewing matches the condition. For example, if you set the condition to Entire Site, it should show everywhere. If set to specific pages, verify those.
+
+Make sure no other active footer template is overriding (Vertex will let multiple footers exist but only the one with the most specific matching condition will show if there’s overlap).
+
+To edit the footer, go to Vertex Addons > Template Builder, find your footer template in the list, and click Edit with Elementor. You can update styles or content, then Update to apply changes globally.
+
+<Aside type="note">Canvas template behavior: Similar to headers, you can include footers on Elementor Canvas pages. In the footer’s Display Conditions, enable **Include in Canvas pages** if you want the footer visible on pages using Elementor’s Canvas template (which normally omit header/footer).</Aside>
+
+By designing a custom footer, you maintain consistent branding and provide important info on every page. Vertex’s Footer Template makes updating footer content easy—change it once in Elementor, and the updates reflect site-wide.

--- a/src/content/docs/vertex/template-builder/header.mdx
+++ b/src/content/docs/vertex/template-builder/header.mdx
@@ -1,8 +1,49 @@
 ---
-title: Header
-description: TODO
+title: Header Template
+description: "Design custom site headers using Vertex’s Template Builder."
 sidebar:
   order: 1
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Creating a custom header allows you to replace your theme’s header with one you design in Elementor. Vertex Addons’ Advanced Template Builder lets you build and assign headers without needing Elementor Pro. Use this to create a consistent, global header or different headers for specific pages.
+
+{/* Image for header creation screen */}
+
+## Overview
+
+A Header Template in Vertex is a top section of your site (logo, navigation, etc.) that you design with Elementor. Once published and conditions set, Vertex will display this header on your site’s pages instead of the theme’s default header. You can include site elements like logos, menus, and search bars using Elementor widgets.
+
+<Aside type="tip">If you’re using a theme that shows a default header, you may need to disable or override it. With Vertex’s header active, your custom header will render at the top of pages. Using a blank canvas or header-less theme (like Hello) is recommended for best results.</Aside>
+
+## Creating a Header Template
+<Steps>
+1. **Open the Template Builder:** In your WordPress dashboard, go to Vertex Addons > Template Builder. Click the “New Template” button (Add New). This will open a dialog to create a new template.
+2. **Configure Template Details:** In the New Template dialog, select Header as the template type. Enter a name (optional, e.g., “Main Header”) for your reference.
+3. **Create and Edit:** Click Create Template. The plugin will generate the Header template and launch the Elementor editor for it. You’ll see a blank header canvas ready to design.
+4. **Design Your Header:** In Elementor, drag and drop widgets to build your header. Common header elements include:
+   - Site Logo: Use the Site Logo widget to automatically pull your site’s logo.
+   - Navigation Menu: Use Elementor’s Nav Menu widget (if available) or a Vertex Advanced Menus widget to add your menu.
+   - Site Title or Tagline: Use Site Title widget (or a Heading with dynamic tag if needed) to show your site name.
+   - Other Elements: Add a Search Input, Social icons, or any other content needed in the header bar.
+   - Responsive Design: Adjust responsive settings for your header (e.g., make sure the menu collapses on mobile). Elementor’s responsive controls can be used to ensure the header looks good on all devices.
+5. **Set Display Conditions:** In the Elementor editor’s sidebar, find the Display Conditions (usually under a “Display Conditions” or “Advanced” tab added by Vertex). Enable conditions and choose where this header should appear. For a global header, select Entire Site. You can also assign the header to specific pages or sections of the site if desired (e.g., a different header for blog pages).
+6. **Publish the Header:** Click Publish (or Update if editing) to save. If asked to set conditions, confirm the conditions you chose and finalize.
+
+</Steps>
+
+## After Publishing
+
+Once published and conditions are set, your custom header will automatically replace the theme’s header on the chosen pages. Visit your site’s frontend to verify the header appearance. You should see your designed header at the top of the page. If it’s not appearing, double-check that:
+
+The template is Published (not in draft).
+
+Display conditions were properly set (e.g., “Entire Site” for all pages).
+
+No other header template is conflicting (if multiple headers are published, the most specific condition will apply).
+
+You can edit the header any time by returning to Vertex Addons > Template Builder, finding your Header template in the list, and clicking Edit with Elementor. Any changes you save will instantly apply to your site’s header.
+
+<Aside type="note">Including a header on Elementor **Canvas** templates: If you use Elementor’s Canvas page template (which by default has no header), Vertex provides an option “Include in Canvas pages” in the header’s Display Conditions. Enable this if you want your header to show even on pages using the Canvas layout.</Aside>
+
+By using the Header Template feature, you gain full creative control over your site’s header design without writing code. Your custom header can include dynamic elements and will remain consistent across your site as defined by your conditions.

--- a/src/content/docs/vertex/template-builder/index.mdx
+++ b/src/content/docs/vertex/template-builder/index.mdx
@@ -1,9 +1,77 @@
 ---
 title: Advanced Template Builder
-description: TODO
+description: "Use Vertex’s Advanced Template Builder to create custom Headers, Footers, Single post layouts, Archive pages, and more without Elementor Pro."
 sidebar:
   label: Advanced Template Builder
   order: 3
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Vertex Addons’ Advanced Template Builder is a powerful feature that brings theme building capabilities to Elementor Free. It allows you to create and manage templates for different parts of your website (like header, footer, single post, archive, etc.) and set where they appear. Essentially, you gain Elementor Pro-like Theme Builder functionality at no extra cost.
+
+## What is the Advanced Template Builder?
+
+The Advanced Template Builder is an interface in the WordPress dashboard (under Vertex Addons) where you can create templates for various site areas:
+
+Header – Custom site header designs.
+
+Footer – Custom footer designs.
+
+Single – Layout for single posts or pages.
+
+Archive – Layout for archive pages (blog index, categories, search results, etc.).
+
+Dynamic Loop Item – Template for repeated post items in grids or loops.
+
+Each template is built with Elementor’s editor, using Vertex’s added widgets and dynamic tags for site data. Once a template is published, Vertex will display it on the site according to conditions you specify (for example, using your custom header on the entire site, or a specific footer only on certain pages).
+
+<Aside type="tip">**No Elementor Pro needed:** The Advanced Template Builder works with Elementor Free. It unlocks the ability to override theme parts (which is usually a pro feature in Elementor). This means you can build a fully custom header-footer and blog design without upgrading Elementor.</Aside>
+
+## How to Create and Use Templates
+
+Using the Template Builder is straightforward and similar for each template type:
+<Steps>
+1. **Access the Builder:** Go to Vertex Addons > Template Builder in WP admin. Here you’ll see a list of existing templates (if any) and a button to add new.
+2. **Add a New Template:** Click “New Template”. In the dialog that appears:
+   - Choose Type: Select which type of template you want to create (Header, Footer, Single, Archive, or Dynamic Loop Item).
+   - Name: Enter an optional name (this is just for your reference, e.g., “Blog Archive Template”).
+   - Click Create Template.
+3. **Edit in Elementor:** After creation, the template will open in the Elementor editor. Design the template as desired:
+   - You can use regular Elementor widgets and any Vertex widgets (many Vertex widgets are specifically useful for theme parts, like Post Title, Site Logo, Archive Title, etc.).
+   - For Single templates, use dynamic widgets (Post Title, Post Content, Featured Image, etc.) to pull in actual post data.
+   - For Archive templates, you might add an Archive Title widget and a posts listing (using Dynamic Archive Posts widget).
+   - For Headers/Footers, design the layout and include relevant site elements.
+4. **Display Settings & Conditions:** Before publishing, configure where this template should apply:
+   - In the Elementor editor panel, find Display Conditions (added by Vertex in the template’s Settings). Enable it and set the conditions. For example, for a Single Post template, you might choose “Posts – All” to apply to all blog posts (or a specific category of posts if needed). For a Header, you might set it to Entire Site.
+   - You can add multiple conditions or exclude conditions if necessary. For instance, a header could be set to Entire Site but excluding a landing page.
+5. **Publish the Template:** Click Publish. Elementor (with Vertex) will prompt to confirm the display conditions if you haven’t already. Finalize these settings and publish.
+6. **Review Active Templates:** Back in Vertex Addons > Template Builder, you’ll now see your new template listed alongside its type. You can create multiple templates of the same type if you need variations for different sections of your site (e.g., a different Single template for pages vs. posts).
+</Steps>
+
+## How Vertex Applies Your Templates
+
+Once a template is published:
+
+Vertex injects your template’s content into the site at the appropriate hook. For example, a Header template will be displayed at the top of the page, a Footer at the bottom, replacing the theme’s output. Single and Archive templates will override the content area for posts or archives.
+
+Priority: If more than one template of the same type could apply (overlapping conditions), Vertex will use the most specific match. (For instance, if you have one Single template for “All Posts” and another for a specific category, the specific category one will show for posts in that category.)
+
+Dynamic content: While editing a template, you can choose a preview source (Vertex adds a “Preview Source” dropdown in the editor’s settings). This lets you see an example post or archive while designing. It doesn’t affect where the template displays; that’s controlled by conditions.
+
+<Aside>For example, you might create two Single Post templates – one for standard blog posts and one for a custom post type. Using display conditions, assign each to the appropriate content. The Template Builder will ensure each post type shows the correct design.</Aside>
+
+## Managing Templates
+
+All your templates are listed under Vertex Addons > Template Builder. Here you can:
+
+Edit a template (to change its design or update content).
+
+Quick Edit to rename if needed.
+
+Trash a template if you no longer need it.
+
+Status: Draft templates will not take effect until published.
+
+Remember that if you want to temporarily disable a custom template, you can save it as Draft. In that case, your theme’s default design will resume for that part of the site until the template is published again.
+
+The Advanced Template Builder essentially hands you the reins of your site’s theme. You can craft the exact header, footer, and content layouts you envision, all within Elementor’s familiar interface. Once set up, your site’s structure becomes easy to maintain – edit the template once to update that part of your site everywhere.

--- a/src/content/docs/vertex/template-builder/single.mdx
+++ b/src/content/docs/vertex/template-builder/single.mdx
@@ -1,8 +1,89 @@
 ---
-title: Single
-description: TODO
+title: Single Post Template
+description: "Create custom single post/page layouts with Vertex’s Single Template to control how individual content is presented."
 sidebar:
   order: 4
 ---
+import { Aside, Steps } from '@astrojs/starlight/components';
 
-Content coming soon.
+Vertex allows you to design the layout for individual posts or pages using the Single Template feature. This is perfect for customizing the appearance of blog posts, pages, or other single post types (like custom post types) beyond what your theme offers. You can include dynamic elements such as the post title, content, author, etc., in any arrangement you like.
+
+## What is a Single Template?
+
+A Single Template defines the structure for a single piece of content – for example, a blog post or a static page. Instead of the theme’s default post layout, which might have a fixed title placement and metadata, a Vertex Single Template lets you decide where everything goes and how it looks using Elementor.
+
+Common uses:
+
+Create a branded blog post design (with author info box, related posts section, etc.).
+
+Design a page layout for all standard pages (if you want a uniform look or special banner on every page).
+
+Style custom post type entries (if your site has portfolio items, events, etc., and you want a specific layout for them).
+
+## Creating a Single Template
+<Steps>
+1. **Add a New Single Template:** Go to Vertex Addons > Template Builder and click “New Template.” In the dialog, choose Single as the type. Optionally name it (e.g., “Blog Post Template” or “Page Template”) and click Create Template.
+2. **Edit in Elementor:** The Elementor editor opens for your new Single template. You now build the layout as you want an individual post/page to appear:
+   - Post Title: Drag in the Post Title widget (Vertex provides this) to where you want the title to show (usually at top). This widget will dynamically display the title of the post when viewed.
+   - Post Content: Insert the Post Content widget. This is crucial – it outputs the main content of the post/page that you wrote in the editor. Place it in the layout where the article text should go.
+   - Featured Image: If you want the featured image displayed, use the Post Featured Image widget. You can, for example, put it above the title as a full-width banner image, or as a thumbnail within the content – your design choice.
+   - Post Meta: To show meta information like author, date, categories, etc., you can use a combination of Vertex widgets:
+     - Post Date widget to show the date (or use a dynamic tag in a Text widget, formatted as needed).
+     - Post Author (Author Box widget or dynamic Author Name tag in text).
+     - Post Terms widget for categories/tags if desired (Vertex offers Post Terms widget/dynamic tag to list categories).
+     - Comments – you can include a Post Comments widget to show the comments list or a Comments Form widget for the comment form.
+   - Arrange these elements in the desired order. For instance, a classic blog post layout might be: Featured Image -> Post Title -> Meta (date/author) -> Post Content -> Comments.
+   - Add any additional design flairs: an author bio section (using Author Box widget), social share buttons (if you have a plugin or widget), etc.
+   - Global vs Specific: Decide if this template is for all single posts, all pages, or specific content:
+     - If it’s for blog posts, design with posts in mind (e.g., include categories, author, etc.).
+     - If it’s for pages, you might exclude some elements (like author or date, since pages often don’t show those). You can create separate templates for each if needed (one for posts, one for pages).
+   - Responsive Design: Check how the layout looks on mobile and tablet in Elementor. Ensure images resize properly and text is readable. Adjust sections (for example, you might center the title on mobile, or reorder elements using Elementor’s responsive settings).
+3. **Set Display Conditions:** Before publishing, set where this template applies:
+   - Click the gear/settings icon in Elementor (bottom left) to open the Document Settings, find Display Conditions.
+   - For a blog post template: under Single, choose Posts – All (this will apply to all posts of the default “Posts” type).
+   - For a page template: choose Pages – All.
+   - You can target specific categories of posts too. For instance, if this template is only for posts in the “News” category, set a condition for that under Singular conditions. (However, category-specific single design is less common than archive-specific; most likely you’ll use All Posts.)
+   - You can add multiple conditions. E.g., apply to “All Posts” and maybe also to a custom post type if you want the same layout for both.
+   - Publish: Click Publish and confirm the conditions. Now your single template is active.
+
+</Steps>
+
+## Viewing the Custom Single Template
+
+After publishing, check an example piece of content:
+
+If you created a posts template, open any blog post on your site. It should now use the layout you designed (with your chosen placement of title, image, etc.).
+
+If a pages template, view a regular page.
+
+Verify:
+
+The Post Title is showing the actual title of the post.
+
+The Post Content widget is outputting the full content you wrote for that post (formatting intact).
+
+Other dynamic bits (date, author, categories, comments) are correct for that post.
+
+The styling matches what you set in Elementor (fonts, colors, spacing).
+
+If you don’t see the new design:
+
+Make sure no other Single template with a conflicting condition is overriding. If two templates could apply to the same post, the one with more specific condition takes precedence.
+
+Ensure the post/page you’re checking meets the condition. For example, if you only applied the template to “Posts”, it won’t affect pages.
+
+Clear any cache (if using caching plugins) to ensure you’re seeing fresh output.
+
+## Tips for Single Templates
+
+Multiple Templates: You can have different single templates for different post types. For instance, a separate layout for a Custom Post Type (CPT) like “Portfolio”. Vertex will list custom post types in Display Conditions if available. (E.g., you might see an option for that CPT under Single conditions if it’s public.)
+
+Dynamic Tags: Utilize dynamic tags in text widgets for flexibility. For example, instead of separate widgets, you could add a Text Editor widget and insert dynamic tags for author name, date, etc., inline with custom separators. Vertex’s dynamic tags include Post Title, Post Excerpt, Post Date, Author Name, etc., which you can embed in text or heading widgets for unique layouts.
+
+Consistency: If you want a uniform look for all single content, ensure you’ve covered both Posts and Pages. You might need one template for each if they should differ. If they should be the same, you still currently have to create two (one for all posts, one for all pages) since conditions separate them.
+
+Page Builders vs Theme: Once your single template is active, it takes over the content layout. If you find your theme’s elements (like the default title) still showing, it means the Vertex template might not be applying — usually due to conditions. Double-check conditions in that case.
+
+<Aside type="tip">You can include Elementor sections or widgets that only show under certain conditions if needed. For example, using Visibility Controls (an extension from Vertex) to show an “Author Bio” only on posts and not on pages within a unified template. This is an advanced use, but it’s possible to tailor sections within one template using such extensions.</Aside>
+
+With a Single Post Template in place, editing the design of your blog posts or pages becomes centralized. Change the template’s design and it updates the look of all those posts, ensuring consistency and saving time compared to editing each post individually.


### PR DESCRIPTION
## Summary
- document header and footer templates for custom site sections
- explain archive, single, and loop item templates using Advanced Template Builder
- add guides for popup builder, dynamic tags, and template kit importer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a3e950d0f8832cbcc1f7cd4beb4730