### PR TITLE
feat: add optional header button

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig({
       customCss: ['./src/styles/app.css'],
       components: {
         SocialIcons: './src/components/SocialIcons.astro',
+        PageTitle: './src/components/PageTitle.astro',
       },
     }),
   ],

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -1,0 +1,41 @@
+---
+const PAGE_TITLE_ID = '_top';
+const { title, header_button } = Astro.locals.starlightRoute.entry.data;
+---
+<div class="page-title-wrapper">
+  <h1 id={PAGE_TITLE_ID}>{title}</h1>
+  {header_button && (
+    <a href={header_button.url} class="header-button" target="_blank" rel="noopener noreferrer">
+      {header_button.label}
+    </a>
+  )}
+</div>
+
+<style>
+  @layer starlight.core {
+    .page-title-wrapper {
+      margin-top: 1rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+    .page-title-wrapper h1 {
+      margin: 0;
+      font-size: var(--sl-text-h1);
+      line-height: var(--sl-line-height-headings);
+      font-weight: 600;
+      color: var(--sl-color-white);
+    }
+    .header-button {
+      padding: 0.5rem 0.75rem;
+      background-color: var(--sl-color-accent);
+      color: var(--sl-color-white);
+      border-radius: 0.25rem;
+      text-decoration: none;
+      font-size: 0.875rem;
+    }
+    .header-button:hover {
+      opacity: 0.9;
+    }
+  }
+</style>

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -29,7 +29,7 @@ const { title, header_button } = Astro.locals.starlightRoute.entry.data;
     .header-button {
       padding: 0.5rem 0.75rem;
       background-color: var(--sl-color-accent);
-      color: var(--sl-color-white);
+      color: #ffffff;
       border-radius: 0.25rem;
       text-decoration: none;
       font-size: 0.875rem;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,19 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: z.object({
+        header_button: z
+          .object({
+            label: z.string(),
+            url: z.string().url(),
+          })
+          .optional(),
+      }),
+    }),
+  }),
 };

--- a/src/content/docs/vertex/widgets/content-layout/accordion.mdx
+++ b/src/content/docs/vertex/widgets/content-layout/accordion.mdx
@@ -3,9 +3,6 @@ title: Accordion Widget
 description: Organize content in collapsible sections using the Accordion widget for Elementor.
 sidebar:
   order: 2
-header_button:
-  label: View Demo
-  url: https://demo.webilia.com/page/
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';

--- a/src/content/docs/vertex/widgets/content-layout/accordion.mdx
+++ b/src/content/docs/vertex/widgets/content-layout/accordion.mdx
@@ -3,6 +3,9 @@ title: Accordion Widget
 description: Organize content in collapsible sections using the Accordion widget for Elementor.
 sidebar:
   order: 2
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/page/
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary
- add `PageTitle` component that renders an optional demo button when frontmatter defines `header_button`
- register the custom PageTitle in Astro config
- example usage in Accordion widget page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Entry docs → 404 was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a643db6048832ca1876a893c089f5c