### PR TITLE
feat: build breadcrumbs from folders

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,42 +1,38 @@
 ---
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
 const route = Astro.locals.starlightRoute;
-const { entry, sidebar } = route;
+const { entry } = route;
 // If breadcrumb explicitly disabled in frontmatter, do not render anything.
 const { breadcrumb } = entry.data;
 if (breadcrumb === false) return;
 
-const normalize = (path) => (path.endsWith('/') ? path : path + '/');
+const docsRoot = fileURLToPath(new URL('../content/docs', import.meta.url));
 
-function flatten(entries, parents = []) {
-  return entries.flatMap((e) =>
-    e.type === 'link'
-      ? [{ ...e, parents }]
-      : flatten(e.entries, [...parents, e.label])
-  );
-}
-const links = flatten(sidebar);
-const findLink = (path) => links.find((l) => normalize(l.href) === normalize(path));
+const toTitle = (slug) =>
+  slug
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ');
+
+const hasIndex = (segs) =>
+  existsSync(path.join(docsRoot, ...segs, 'index.mdx'));
 
 const segments = Astro.url.pathname.split('/').filter(Boolean);
 const crumbs = [];
-if (segments.length) {
-  const product = segments[0];
-  const rootLabel = product.charAt(0).toUpperCase() + product.slice(1);
-  crumbs.push({ label: rootLabel, href: `/${product}/` });
-  for (let i = 1; i < segments.length; i++) {
-    const path = '/' + segments.slice(0, i + 1).join('/') + '/';
-    if (i === segments.length - 1) {
-      crumbs.push({ label: entry.data.title });
-    } else {
-      const link = findLink(path);
-      if (link) {
-        let label = link.label.replace(/ Overview$/i, '');
-        if (/^overview$/i.test(label) && link.parents.length) {
-          label = link.parents[link.parents.length - 1];
-        }
-        crumbs.push({ label, href: link.href });
-      }
-    }
+
+for (let i = 0; i < segments.length; i++) {
+  if (i === segments.length - 1) {
+    crumbs.push({ label: entry.data.title });
+  } else {
+    const pathSegments = segments.slice(0, i + 1);
+    const label = toTitle(segments[i]);
+    const href = hasIndex(pathSegments)
+      ? `/${pathSegments.join('/')}/`
+      : undefined;
+    crumbs.push({ label, href });
   }
 }
 ---


### PR DESCRIPTION
## Summary
- build breadcrumbs from folder hierarchy
- link segments only when an index.mdx exists

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68adedbd7560832ca06a868f3b1ad043