### PR TITLE
Refactor sidebar label front matter

### DIFF
--- a/src/content/docs/listdom/addons/multiple-categories.mdx
+++ b/src/content/docs/listdom/addons/multiple-categories.mdx
@@ -1,8 +1,8 @@
 ---
 title: Multiple Categories Addon
-sidebar_label: Multiple Categories
 description: "Allows each listing to be assigned to multiple categories instead of just one primary category."
 sidebar:
+  label: Multiple Categories
   order: 23
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/addons/pms.mdx
+++ b/src/content/docs/listdom/addons/pms.mdx
@@ -1,8 +1,8 @@
 ---
 title: Paid Member Subscriptions Addon
-sidebar_label: Paid Member Subscriptions
 description: "Control listing visibility based on Paid Member Subscriptions membership levels."
 sidebar:
+  label: Paid Member Subscriptions
   order: 24
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/addons/pro.mdx
+++ b/src/content/docs/listdom/addons/pro.mdx
@@ -1,8 +1,8 @@
 ---
 title: Pro Addon
-sidebar_label: Listdom Pro
 description: "Unlocks premium features including front-end submissions, user dashboards, advanced display settings, and more."
 sidebar:
+  label: Listdom Pro
   order: 25
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/managing-listings/add-edit-listing.mdx
+++ b/src/content/docs/listdom/managing-listings/add-edit-listing.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Add or Edit Listing"
-sidebar_label: Add/Edit Listing
 description: "Guide to all options available when adding a new listing or editing an existing listing in Listdom."
 sidebar:
+  label: Add/Edit Listing
   order: 1
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/search-filtering/create-search-filter-form.mdx
+++ b/src/content/docs/listdom/search-filtering/create-search-filter-form.mdx
@@ -1,8 +1,8 @@
 ---
 title: How to Create a Search and Filter Form
-sidebar_label: How to Create a Search Form
 description: "Learn how to build custom search and filter forms in Listdom to let users find listings easily."
 sidebar:
+  label: How to Create a Search Form
   order: 1
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/search-filtering/search-form-fields-and-options.mdx
+++ b/src/content/docs/listdom/search-filtering/search-form-fields-and-options.mdx
@@ -1,8 +1,8 @@
 ---
 title: Search and Filter Form Available Fields and Options
-sidebar_label: Search Form Fields
 description: "Details of every available search field type in Listdom and how to configure their display options."
 sidebar:
+  label: Search Form Fields
   order: 2
 header_button:
   label: View Demo

--- a/src/content/docs/listdom/settings/api.mdx
+++ b/src/content/docs/listdom/settings/api.mdx
@@ -1,8 +1,8 @@
 ---
 title: "API"
-sidebar_label: "API Reference"
 description: "Developer API reference for Listdom, including authentication tokens and endpoints for login, registration, listing retrieval, image upload, and listing management."
 sidebar:
+  label: "API Reference"
   order: 8
 header_button:
   label: View Demo


### PR DESCRIPTION
## Summary
- Inline sidebar labels under `sidebar.label` front matter for docs where label differs from page title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b51d81ffa4832cbd13b0a0f8f7c1dd