### PR TITLE
chore: remove quotes from listdomer theme descriptions

### DIFF
--- a/src/content/docs/listdom/listdomer-theme/demo-import.mdx
+++ b/src/content/docs/listdom/listdomer-theme/demo-import.mdx
@@ -1,7 +1,7 @@
 ---
 title: Demo Import
 sidebar_label: Demo Import
-description: "Use One Click Demo Import to quickly set up a fully designed site with Listdomer’s demo content."
+description: Use One Click Demo Import to quickly set up a fully designed site with Listdomer’s demo content.
 sidebar:
   order: 2
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/installation-setup.mdx
+++ b/src/content/docs/listdom/listdomer-theme/installation-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installation & Setup
 sidebar_label: Installation & Setup
-description: "Follow these steps to get the Listdomer theme up and running on your WordPress site."
+description: Follow these steps to get the Listdomer theme up and running on your WordPress site.
 sidebar:
   order: 1
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/page-templates.mdx
+++ b/src/content/docs/listdom/listdomer-theme/page-templates.mdx
@@ -1,7 +1,7 @@
 ---
 title: Page Templates & Layouts
 sidebar_label: Page Templates & Layouts
-description: "Learn how Listdomer structures pages and how to customize headers, footers, and layouts for different content types."
+description: Learn how Listdomer structures pages and how to customize headers, footers, and layouts for different content types.
 sidebar:
   order: 3
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/settings/appearance.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/appearance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Colors, Typography & Page Heading
 sidebar_label: Colors, Typography & Page Heading
-description: "Customize global colors, fonts, and the page header banner in Listdomer."
+description: Customize global colors, fonts, and the page header banner in Listdomer.
 sidebar:
   order: 2
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/settings/content-misc.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/content-misc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Content & Misc Settings
 sidebar_label: Content & Misc Settings
-description: "Control blog layout, search behavior, the 404 page, widget styling, and custom code in Listdomer."
+description: Control blog layout, search behavior, the 404 page, widget styling, and custom code in Listdomer.
 sidebar:
   order: 3
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/settings/general-header-footer.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/general-header-footer.mdx
@@ -1,7 +1,7 @@
 ---
 title: General, Header & Footer Settings
 sidebar_label: General, Header & Footer
-description: "Configure global site identity and header and footer options in Listdomer."
+description: Configure global site identity and header and footer options in Listdomer.
 sidebar:
   order: 1
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/demo-import.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/demo-import.mdx
@@ -1,7 +1,7 @@
 ---
 title: Demo Import Issues
 sidebar_label: Demo Import Issues
-description: "Fix problems encountered while importing Listdomer demo content."
+description: Fix problems encountered while importing Listdomer demo content.
 sidebar:
   order: 2
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/functionality-integration.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/functionality-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Functionality & Integration Issues
 sidebar_label: Functionality & Integration Issues
-description: "Address problems with theme features, Listdom add-ons, and other integrations."
+description: Address problems with theme features, Listdom add-ons, and other integrations.
 sidebar:
   order: 4
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/installation-update.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/installation-update.mdx
@@ -1,7 +1,7 @@
 ---
 title: Installation & Update Issues
 sidebar_label: Installation & Update Issues
-description: "Resolve common problems during theme installation or updates."
+description: Resolve common problems during theme installation or updates.
 sidebar:
   order: 1
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/layout-display.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/layout-display.mdx
@@ -1,7 +1,7 @@
 ---
 title: Layout & Display Issues
 sidebar_label: Layout & Display Issues
-description: "Solve visual problems with headers, footers, sidebars, and page titles."
+description: Solve visual problems with headers, footers, sidebars, and page titles.
 sidebar:
   order: 3
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/widgets/contact-widget.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/contact-widget.mdx
@@ -1,7 +1,7 @@
 ---
 title: Listdomer Contact Widget
 sidebar_label: Listdomer Contact Widget
-description: "Display contact details and social icons using the (Listdomer) Contact widget."
+description: Display contact details and social icons using the (Listdomer) Contact widget.
 sidebar:
   order: 2
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/widgets/shortcodes-elementor.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/shortcodes-elementor.mdx
@@ -1,7 +1,7 @@
 ---
 title: Shortcodes & Elementor Integration
 sidebar_label: Shortcodes & Elementor
-description: "Use Listdom shortcodes and Elementor widgets to display listings and design headers or footers."
+description: Use Listdom shortcodes and Elementor widgets to display listings and design headers or footers.
 sidebar:
   order: 3
 header_button:

--- a/src/content/docs/listdom/listdomer-theme/widgets/widget-areas.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/widget-areas.mdx
@@ -1,7 +1,7 @@
 ---
 title: Widget Areas
 sidebar_label: Widget Areas
-description: "Use Listdomer's sidebars and footer widget areas to place content."
+description: Use Listdomer's sidebars and footer widget areas to place content.
 sidebar:
   order: 1
 header_button:


### PR DESCRIPTION
## Summary
- remove unnecessary double quotes from description headers across Listdomer theme docs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b5b910e704832ca2d8888b74319834