### PR TITLE
refactor: replace tip badges with asides

### DIFF
--- a/src/content/docs/listdom/addons/ads.mdx
+++ b/src/content/docs/listdom/addons/ads.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 The **Listdom Ads Addon** allows you to insert advertisement content into your listing pages. This is ideal for monetizing your directory by displaying ads (such as banners, affiliate ads, or custom HTML/shortcodes) within individual listings. The addon provides both a global ad (shown on all listings) and per-listing ad fields for customized advertising.
 
@@ -25,7 +25,7 @@ The addon adds an **"Ads"** module to listing submission and edit forms. When ad
 - **Per Listing Content:** If you want a particular listing to show a unique advertisement (for example, a sponsored banner just for that listing's owner), enter the content in this field for that listing. This content can include HTML for images, scripts, or shortcodes - anything that you would normally put in the global ad field can be put here as well.
 - **Fallback Behavior:** If this field is left empty for a listing, the system will default to showing the Global Ad content on that listing's page. If the Global Ad is also empty, then no ad section will appear for that listing at all.
 
-<Aside type="tip">You can use the WordPress **WYSIWYG editor** in the Ads field to format your ad content or to paste ad code. This makes it easy to integrate third-party ad scripts. Also, consider using shortcodes from ad manager plugins in this field for advanced rotation or tracking <Badge text="Tip" />.</Aside>
+<Aside type="tip">You can use the WordPress **WYSIWYG editor** in the Ads field to format your ad content or to paste ad code. This makes it easy to integrate third-party ad scripts. Also, consider using shortcodes from ad manager plugins in this field for advanced rotation or tracking.</Aside>
 
 ## Listing Detail Page Ads Section
 
@@ -43,7 +43,8 @@ For the ad content (global or per-listing) to appear on the front-end, the **Ads
   <Card title="Global Banner on All Listings">
     A directory site wants to show a banner ad on every listing page. The admin pastes an AdSense code into the **Global Ad** setting. Now, every listing page displays this banner at the bottom of the content, generating revenue no matter which listing is viewed.
   </Card>
-  <Card title="Ad Manager Integration">
-    A site admin uses a shortcode from an ad management plugin within the **Global Ad** field. <Badge text="Tip" /> This shortcode rotates multiple ads. With the Ads Addon, every listing now shows the rotating ads snippet, providing variety and better monetization without editing each listing.
-  </Card>
+    <Card title="Ad Manager Integration">
+      A site admin uses a shortcode from an ad management plugin within the **Global Ad** field.
+      <Aside type="tip">This shortcode rotates multiple ads.</Aside> With the Ads Addon, every listing now shows the rotating ads snippet, providing variety and better monetization without editing each listing.
+    </Card>
 </CardGrid>

--- a/src/content/docs/listdom/listdomer-theme/demo-import.mdx
+++ b/src/content/docs/listdom/listdomer-theme/demo-import.mdx
@@ -5,7 +5,7 @@ description: Use One Click Demo Import to quickly set up a fully designed site w
 sidebar:
   order: 2
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Use One Click Demo Import to quickly set up a fully designed site with Listdomer's demo content.
 
@@ -13,7 +13,7 @@ Use One Click Demo Import to quickly set up a fully designed site with Listdomer
 
 <Steps>
 1. **Open the Demo Importer:** In your dashboard, go to Listdomer > Demo Import. You will see a selection of available demo designs (e.g. General Directory, Real Estate, Business Directory).
-2. **Choose a Demo:** Click on your desired demo. A preview image and name will help identify the style. For example: "General Directory" - a multi-purpose directory layout (default); "Real Estate Directory" - a property listing design with real estate features <Badge text="Pro" />; "Business Directory" - a listings layout focused on local businesses.
+2. **Choose a Demo:** Click on your desired demo. A preview image and name will help identify the style. For example: "General Directory" - a multi-purpose directory layout (default); "Real Estate Directory" - a property listing design with real estate features; "Business Directory" - a listings layout focused on local businesses.
 3. **Import:** Click the Import button and confirm. The importer will download and install:
    - Pages & Posts: Sample pages (Home, About, Contact, etc.) and dummy listings/posts.
    - Images & Media: Placeholder images for design consistency.
@@ -24,7 +24,7 @@ Use One Click Demo Import to quickly set up a fully designed site with Listdomer
 </Steps>
 
 <Aside type="note">
-The *Real Estate Directory* demo requires additional Listdom add-ons. During import, it will prompt to install **Listdom Real Estate Toolkit** and **WooCommerce**. These are premium integrations <Badge text="Pro" />. If you proceed, the importer will install them from Webilia's servers. Without these, the real estate-specific content (like property attributes) won't function fully.
+The *Real Estate Directory* demo requires additional Listdom add-ons. During import, it will prompt to install **Listdom Real Estate Toolkit** and **WooCommerce**. These are premium integrations. If you proceed, the importer will install them from Webilia's servers. Without these, the real estate-specific content (like property attributes) won't function fully.
 </Aside>
 
 ## Post-Import Steps
@@ -52,7 +52,7 @@ Already have content? It's **not recommended** to import a demo on a live site w
 <CardGrid>
   <Card>**General Directory Demo** - Ideal for a broad range of directory websites. Importing this will set up a versatile homepage with a search bar and multiple listing sections (e.g. recent listings, categories), a blog section, and predefined category pages. Use this if you want a multi-category listing site out of the box.</Card>
 
-  <Card>Real Estate Demo <Badge text="Pro" /> - Tailored for property listings. After import, you get a homepage with advanced property search forms (Rent/Buy tabs), property listing templates, and integration with real estate features (requires the Real Estate Toolkit). Choose this if you intend to build a real estate portal. Note: Ensure WooCommerce and the toolkit are active for full functionality.</Card>
+  <Card>Real Estate Demo - Tailored for property listings. After import, you get a homepage with advanced property search forms (Rent/Buy tabs), property listing templates, and integration with real estate features (requires the Real Estate Toolkit). Choose this if you intend to build a real estate portal. Note: Ensure WooCommerce and the toolkit are active for full functionality.</Card>
 
   <Card>Post-Import Customization - Once a demo is imported, you can easily swap out content. For example, on the imported Contact page, simply edit the contact form shortcode to use your form plugin of choice (or update the email address in the form). The imported About Us page provides a pre-set layout which you can replace text for to quickly launch your site.</Card>
 </CardGrid>

--- a/src/content/docs/listdom/listdomer-theme/installation-setup.mdx
+++ b/src/content/docs/listdom/listdomer-theme/installation-setup.mdx
@@ -5,7 +5,7 @@ description: Follow these steps to get the Listdomer theme up and running on you
 sidebar:
   order: 1
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Follow these steps to get the Listdomer theme up and running on your WordPress site.
 
@@ -26,7 +26,7 @@ Listdom (Webilia's directory plugin): Recommended. The theme is designed to work
 One Click Demo Import: Recommended. Enables easy demo content import (see Demo Import guide).
 
 <Aside type="note">
-If you have **Listdomer Pro** <Badge text="Pro" /> (the premium version of the theme), upload and activate it as a separate theme. It will automatically override the free version with additional features (e.g. extra header/footer styles). Always update the core Listdom plugin and addons to the latest versions for full compatibility.
+If you have **Listdomer Pro** (the premium version of the theme), upload and activate it as a separate theme. It will automatically override the free version with additional features (e.g. extra header/footer styles). Always update the core Listdom plugin and addons to the latest versions for full compatibility.
 </Aside>
 
 ## Basic Setup and Configuration

--- a/src/content/docs/listdom/listdomer-theme/page-templates.mdx
+++ b/src/content/docs/listdom/listdomer-theme/page-templates.mdx
@@ -5,7 +5,7 @@ description: Learn how Listdomer structures pages and how to customize headers, 
 sidebar:
   order: 3
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Learn how Listdomer structures pages and how to customize headers, footers, and layouts for different content types.
 
@@ -16,7 +16,7 @@ Listdomer comes with multiple pre-defined header and footer templates that you c
 Header Types 1-5: These are different structural layouts for the top of your site (logo + menu + extras). For example, Header Type 1 might have the logo left and menu right, Header Type 2 could center the logo above a centered menu, etc. You can preview these by switching the Header Type setting (see Header Settings guide). All header types include the primary menu and optional buttons (Add Listing, Login) in some configuration.
 
 <Aside type="note">
-Header Types beyond the default may require Pro <Badge text="Pro" />; in the free version you might have only Type 1 (and possibly Type 2) active.
+Header Types beyond the default may require Pro; in the free version you might have only Type 1 (and possibly Type 2) active.
 </Aside>
 
 Footer Types 1-5 + Tiny: Footer Type 1 is a classic four-column footer (using Footer 1-4 widget areas). Other types might arrange widgets differently (e.g., Type 2 could be three columns, Type 3 two columns and a logo, etc.) and Tiny footer is just a slim bar typically containing the copyright text and maybe a small menu. Choose a footer type that best displays the info you want. For instance, if you only need a simple footer with minimal info, you might use Tiny or a two-column type.

--- a/src/content/docs/listdom/listdomer-theme/settings/appearance.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/appearance.mdx
@@ -5,7 +5,7 @@ description: Customize global colors, fonts, and the page header banner in Listd
 sidebar:
   order: 2
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Adjust site-wide colors and typography, and control the page heading banner.
 
@@ -27,7 +27,8 @@ Adjust site-wide colors and typography, and control the page heading banner.
 - **Enable Page Header Section:** A master switch to show or hide the page title section globally. If you turn this off, page titles will not be shown in the designed banner.
 - **Title & Description Typography:** Customize the font styling for the page title and optional description text in the banner. By default, titles are large and centered (e.g., 42px, Poppins, semi-bold).
 - **Background for Banner:** Choose a background color or image for the page header area. Options allow setting the image position, repeat, size, and scroll behavior.
-- **Banner Border & Shapes:** Add a bottom border or divider to the banner. There's also a toggle "Enable Shapes" <Badge text="Tip" /> to add abstract shape graphics in the banner background for style.
+- **Banner Border & Shapes:** Add a bottom border or divider to the banner.
+  <Aside type="tip">Toggle "Enable Shapes" to add abstract shape graphics in the banner background for style.</Aside>
 - **Archive Page Titles:** Include Context in Title - e.g., show "Category: Travel" vs just "Travel" as the archive title.
 - **Breadcrumbs:** Enable a breadcrumb trail in the page header for archives and pages. If enabled, it appears just below the title.
 - **Archive Description:** For category, tag, and listing taxonomy archive pages, choose to display the description in the banner or after the listing content. The position setting lets you put the description Inside Page Header or After Content or disable it entirely. You can limit the description length and add a "Show More" link after a set number of characters.
@@ -37,6 +38,7 @@ Adjust site-wide colors and typography, and control the page heading banner.
 <CardGrid>
   <Card>**Updating Brand Colors** - Change the Primary Color and Secondary Color in *Colors and Styles*. Buttons and highlights across the site update instantly to match your brand.</Card>
   <Card>**Custom Fonts for Headings** - In *Typography*, set H1 and H2 to a new Google Font and adjust their sizes for a unique look.</Card>
-  <Card>**Minimal Page Header** - Disable "Enable Shapes" <Badge text="Tip" /> in *Page Heading* and set a solid background color for a clean banner.</Card>
+  <Card>**Minimal Page Header** - Set a solid background color for a clean banner.</Card>
 </CardGrid>
+<Aside type="tip">Disable "Enable Shapes" in *Page Heading* for a clean banner.</Aside>
 

--- a/src/content/docs/listdom/listdomer-theme/settings/content-misc.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/content-misc.mdx
@@ -5,7 +5,7 @@ description: Control blog layout, search behavior, the 404 page, widget styling,
 sidebar:
   order: 3
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Manage content presentation and advanced options for your site.
 
@@ -20,7 +20,8 @@ Manage content presentation and advanced options for your site.
 - **Post Title Style:** Adjust the post title typography and text decoration on archive cards.
 - **Pagination Style:** Select Numeric or Next/Previous for the blog pagination links.
 - **Meta Toggles:** Show or hide meta info on post listings: Category, Author, Date.
-- **Posts Per Page:** Control how many posts to show per page on the blog/archive. This setting overrides the WordPress Reading setting <Badge text="Tip" />.
+- **Posts Per Page:** Control how many posts to show per page on the blog/archive.
+  <Aside type="tip">This setting overrides the WordPress Reading setting.</Aside>
 
 ### Single Blog Post Options
 

--- a/src/content/docs/listdom/listdomer-theme/settings/general-header-footer.mdx
+++ b/src/content/docs/listdom/listdomer-theme/settings/general-header-footer.mdx
@@ -5,11 +5,11 @@ description: Configure global site identity and header and footer options in Lis
 sidebar:
   order: 1
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Configure the appearance and behavior of the Listdomer theme via its comprehensive Listdomer Settings panel (powered by Redux).
 
-<Aside type="note">Many options are pre-set if you imported a demo. You can modify them here. All changes are saved in the database (no code editing needed). Pro-only options are marked with a <Badge text="Pro" /> badge in the interface.</Aside>
+<Aside type="note">Many options are pre-set if you imported a demo. You can modify them here. All changes are saved in the database (no code editing needed). Pro-only options are marked in the interface.</Aside>
 
 ## General Settings
 
@@ -22,7 +22,7 @@ Configure the appearance and behavior of the Listdomer theme via its comprehensi
 
 Configure the top section of your site.
 
-- **Header Type:** Choose from multiple pre-designed header layouts. Examples: Type 1 (default header), Type 2 (center logo menu beneath), etc. Some header types may be available only in Pro <Badge text="Pro" />. The selected header applies globally, but you can override it per page.
+- **Header Type:** Choose from multiple pre-designed header layouts. Examples: Type 1 (default header), Type 2 (center logo menu beneath), etc. Some header types may be available only in Pro. The selected header applies globally, but you can override it per page.
 - **Primary Menu Selection:** By default, the theme displays the menu assigned to the Primary location. You can override this by selecting a specific menu for the header here - useful if you have multiple menus and want a certain one in the header without changing menu assignments.
 - **Header Colors:** Pick a header background color (or set transparent), as well as text color for menu links. Separate color settings for hover state and "active" menu item are available to fine-tune the header style.
 - **Logo Background:** A toggle to enable/disable a background behind your logo text/image. By default, Listdomer may put the logo on a colored shape for contrast; you can disable this if your logo itself has proper contrast.
@@ -34,7 +34,7 @@ Configure the top section of your site.
 
 ## Footer Settings
 
-- **Footer Type:** Choose the layout style for your site's footer. Types 1-5 are different column arrangements and designs, and Tiny is a minimal footer bar. Some footer types beyond the default may require Pro <Badge text="Pro" />. Selecting "Disabled" will remove the footer entirely on all pages.
+- **Footer Type:** Choose the layout style for your site's footer. Types 1-5 are different column arrangements and designs, and Tiny is a minimal footer bar. Some footer types beyond the default may require Pro. Selecting "Disabled" will remove the footer entirely on all pages.
 - **Footer Colors:** Customize the footer background color, as well as text color. Ensure your text is legible against the background.
 - **Footer Widgets Notice:** The theme's footer layouts include widget areas. You can manage footer widget content via Appearance > Widgets.
 - **Footer Menu:** Choose a menu for the bottom sub-footer area. If left blank, it will use the menu assigned to the "Sub-Footer" location by default.
@@ -43,7 +43,7 @@ Configure the top section of your site.
 ## Examples
 
 <CardGrid>
-  <Card>**Changing the Header Style** - In *Header Settings*, select **Header Type 3** and save. Your site header instantly changes to the new layout. If Header Type 3 is a <Badge text="Pro" /> feature, make sure Listdomer Pro is active.</Card>
+  <Card>**Changing the Header Style** - In *Header Settings*, select **Header Type 3** and save. Your site header instantly changes to the new layout. If Header Type 3 is a Pro feature, make sure Listdomer Pro is active.</Card>
   <Card>**Per-Page Header Override** - Edit a landing page and in the Listdomer meta box set Header to "Disabled." Publish to hide navigation on that page, creating a clean landing layout.</Card>
   <Card>**Switching Footer Layout** - In *Footer Settings*, choose **Footer Type 2** and add widgets to Footer 1-3. Save to display a three-column footer tailored to your content.</Card>
 </CardGrid>

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/demo-import.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/demo-import.mdx
@@ -5,13 +5,14 @@ description: Fix problems encountered while importing Listdomer demo content.
 sidebar:
   order: 2
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Troubleshooting tips for One Click Demo Import in Listdomer.
 
 ## Demo Import Problems
 
-- **Demo Import Fails or Times Out:** This often relates to server limits. Check your PHP max_execution_time and memory_limit. If import stops, you can rerun it; the importer will skip already imported items, so you can safely run it twice <Badge text="Tip" />.
+- **Demo Import Fails or Times Out:** This often relates to server limits. Check your PHP max_execution_time and memory_limit.
+  <Aside type="tip">If import stops, you can rerun it; the importer will skip already imported items, so you can safely run it twice.</Aside>
 - **Content Imported but Homepage is Blank:** After import, if your homepage shows "[shortcode]" text or missing sections, the Listdom plugin or another required plugin wasn't active during import. Activate them and re-import or manually insert the shortcodes on the page.
 - **Images Not Importing:** The demo images are hosted on Webilia's CDN. If they didn't import, your server might have blocked external URL fetches. Manually download those images from the demo site and add them to your Media Library, or replace with your own images.
 - **Menus or Widgets Not Showing:** If after import the menus or widgets are empty, assign them manually. Refer to the demo's screenshots to see what menus or widgets should be there. The demo import log notes each step - any failures can be addressed by manual configuration.

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/functionality-integration.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/functionality-integration.mdx
@@ -5,7 +5,7 @@ description: Address problems with theme features, Listdom add-ons, and other in
 sidebar:
   order: 4
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Troubleshoot functionality and integration issues for Listdomer and Listdom add-ons.
 
@@ -25,7 +25,8 @@ Troubleshoot functionality and integration issues for Listdomer and Listdom add-
 
 - **Content Overflows or looks misaligned:** This could happen if you insert custom HTML or shortcodes that have their own styling. Use Custom CSS to tweak those elements. Ensure images and tables are within container widths.
 - **Slow Performance:** If you experience slow page loads, consider disabling the preloader animation if enabled. Ensure you have caching and optimized images. The Listdom plugin may load scripts like Google Maps, which can slow pages if used excessively.
-- **Need to Reset Settings:** If you heavily modified settings and want to revert to demo defaults, re-import the Redux settings from the demo or use the Redux panel's reset options. Always back up your settings before resetting <Badge text="Tip" />.
+- **Need to Reset Settings:** If you heavily modified settings and want to revert to demo defaults, re-import the Redux settings from the demo or use the Redux panel's reset options.
+  <Aside type="tip">Always back up your settings before resetting.</Aside>
 
 <Aside type="note">For persistent problems, provide your site URL, theme/plugin version, and screenshots when contacting support.</Aside>
 

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/installation-update.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/installation-update.mdx
@@ -5,7 +5,7 @@ description: Resolve common problems during theme installation or updates.
 sidebar:
   order: 1
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Having issues or unexpected behavior? This guide covers installation and update problems for the Listdomer theme and associated plugins.
 
@@ -13,7 +13,8 @@ Having issues or unexpected behavior? This guide covers installation and update 
 
 - **Theme Not Appearing / Styles Missing:** After activation, if the site still looks like the old theme or has no styling, clear any caching plugins or CDN cache. Ensure that "Listdomer" is the active theme under Appearance > Themes. If using a child theme, verify the child theme has Template: listdomer in its style.css header.
 - **Required Plugins not installed:** The theme requires Listdomer Core and Redux Framework. If you missed the prompt, go to Appearance > Install Plugins and install them. Without Listdomer Core, many features won't work. If Redux is not active, the "Listdomer Settings" menu will be absent - activate Redux to restore it.
-- **Stuck on Old Version:** If you updated the theme but don't see new features, your site might still be using a cached CSS/JS. Hard-refresh your browser and clear any server caches. For major updates, also update the Listdomer Core plugin if provided. The theme and its core plugin should be on matching versions <Badge text="Tip" />.
+- **Stuck on Old Version:** If you updated the theme but don't see new features, your site might still be using a cached CSS/JS. Hard-refresh your browser and clear any server caches. For major updates, also update the Listdomer Core plugin if provided.
+  <Aside type="tip">The theme and its core plugin should be on matching versions.</Aside>
 
 <Aside type="caution">Always back up your site before installing or updating themes and plugins.</Aside>
 

--- a/src/content/docs/listdom/listdomer-theme/troubleshooting/layout-display.mdx
+++ b/src/content/docs/listdom/listdomer-theme/troubleshooting/layout-display.mdx
@@ -5,7 +5,7 @@ description: Solve visual problems with headers, footers, sidebars, and page tit
 sidebar:
   order: 3
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 This guide addresses common layout and display issues in Listdomer.
 
@@ -16,7 +16,7 @@ This guide addresses common layout and display issues in Listdomer.
 - **Page Title Section Too Large/Empty:** If a page's title banner area looks oddly large with nothing in it, possibly the title is hidden but the section is still shown. Disable the entire section or turn it off on that specific page to avoid an awkward blank space.
 - **Sidebar appearing below content:** This usually indicates an HTML markup issue or a CSS float/width problem. Check your widgets for unclosed tags or custom CSS that forces unusual widths.
 
-<Aside type="tip">Use your browser's developer tools to inspect elements and diagnose layout problems <Badge text="Tip" />.</Aside>
+<Aside type="tip">Use your browser's developer tools to inspect elements and diagnose layout problems.</Aside>
 
 ## Examples
 

--- a/src/content/docs/listdom/listdomer-theme/widgets/contact-widget.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/contact-widget.mdx
@@ -5,7 +5,7 @@ description: Display contact details and social icons using the (Listdomer) Cont
 sidebar:
   order: 2
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Listdomer Core provides a custom widget called "(Listdomer) Contact" for use especially in footers.
 
@@ -13,7 +13,8 @@ Listdomer Core provides a custom widget called "(Listdomer) Contact" for use esp
 
 - **Logo and Site Name:** Automatically shows your Site Logo or Site Title at top for branding.
 - **Contact Info:** Fields for Email and Phone - if you fill these in the widget settings, they'll be displayed as "Phone: [your number]" and "Email: [your email]" with appropriate labels. Leave blank any field you don't want shown.
-- **Social Icons:** Enter URLs for various social networks (Facebook, X/Twitter, Instagram, LinkedIn, Pinterest, YouTube, WhatsApp, Telegram) in the widget settings. The widget will display an icon for each service that links to your provided URL <Badge text="Tip" />.
+- **Social Icons:** Enter URLs for various social networks (Facebook, X/Twitter, Instagram, LinkedIn, Pinterest, YouTube, WhatsApp, Telegram) in the widget settings.
+  <Aside type="tip">The widget will display an icon for each service that links to your provided URL.</Aside>
 
 Add this widget to a Footer widget area to create a "Contact us" column. In Appearance > Widgets, add (Listdomer) Contact to your desired sidebar, give it a Title, and fill in your contact info.
 

--- a/src/content/docs/listdom/listdomer-theme/widgets/shortcodes-elementor.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/shortcodes-elementor.mdx
@@ -5,7 +5,7 @@ description: Use Listdom shortcodes and Elementor widgets to display listings an
 sidebar:
   order: 3
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Listdomer fully supports inserting shortcodes in pages or widgets and integrates with Elementor for custom layouts.
 
@@ -25,7 +25,8 @@ Listdomer adds a custom category "Listdomer" with widgets for Elementor:
 - **Tiny:** A mini content block for compact displays.
 - **Testimonials:** Showcase client testimonials.
 
-Elementor integration also enables creating header or footer templates. When you design a template of type "Listdomer Header" or "Listdomer Footer," it appears in the Header Type or Footer Type dropdown so you can apply it site-wide <Badge text="Tip" />.
+Elementor integration also enables creating header or footer templates.
+<Aside type="tip">When you design a template of type "Listdomer Header" or "Listdomer Footer," it appears in the Header Type or Footer Type dropdown so you can apply it site-wide.</Aside>
 
 ## Examples
 

--- a/src/content/docs/listdom/listdomer-theme/widgets/widget-areas.mdx
+++ b/src/content/docs/listdom/listdomer-theme/widgets/widget-areas.mdx
@@ -5,7 +5,7 @@ description: Use Listdomer's sidebars and footer widget areas to place content.
 sidebar:
   order: 1
 ---
-import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
+import { Aside, Steps, Card, CardGrid } from '@astrojs/starlight/components';
 
 Listdomer works seamlessly with WordPress widgets to display content in sidebars and footers.
 
@@ -13,7 +13,8 @@ Listdomer works seamlessly with WordPress widgets to display content in sidebars
 
 The theme registers several widget areas for flexible content placement:
 
-- **Main Sidebar:** Appears on blog pages (archives and single posts) when using a sidebar layout. This sidebar's default ID is "sidebar-1" and typically shows on the right (or left) side of blog content. You can add widgets like Search, Recent Posts, or any custom widget here via Appearance > Widgets. <Badge text="Tip" />
+- **Main Sidebar:** Appears on blog pages (archives and single posts) when using a sidebar layout. This sidebar's default ID is "sidebar-1" and typically shows on the right (or left) side of blog content.
+  <Aside type="tip">You can add widgets like Search, Recent Posts, or any custom widget here via Appearance &gt; Widgets.</Aside>
 - **Footer 1, 2, 3, 4:** Four widget columns in the footer. These are used by footer layouts that have multiple columns. Footer Type 1 might place these four side by side. Add widgets to each to populate your footer columns.
 - **Sub-Footer (Footer Menu):** Not a widget area, but a menu location for a thin bar below the footer widgets.
 


### PR DESCRIPTION
## Summary
- convert Tip badges into tip Asides and adjust surrounding text
- drop Pro badges from Listdomer theme docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b71a3d76b08331ae38af4566420273