### PR TITLE
Add demo header buttons for Listdom addon docs

### DIFF
--- a/src/content/docs/listdom/addons/acf.mdx
+++ b/src/content/docs/listdom/addons/acf.mdx
@@ -3,6 +3,9 @@ title: ACF Addon
 description: Integrate Advanced Custom Fields with Listdom listings, allowing custom fields to appear on submission forms and listing pages.
 sidebar:
   order: 1
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/acf-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/advanced-map.mdx
+++ b/src/content/docs/listdom/addons/advanced-map.mdx
@@ -3,6 +3,9 @@ title: Advanced Map Addon
 description: Enhance Listdom's mapping capabilities with custom map styles, marker customization, infowindow layouts, and user direction features.
 sidebar:
   order: 4
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/advanced-map-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/advanced-portal-search.mdx
+++ b/src/content/docs/listdom/addons/advanced-portal-search.mdx
@@ -3,6 +3,9 @@ title: Advanced Portal Search Addon
 description: Augment Listdom's search functionality with refined taxonomy matching logic and a custom fallback image for listings without featured images.
 sidebar:
   order: 5
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/aps-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/auction.mdx
+++ b/src/content/docs/listdom/addons/auction.mdx
@@ -3,6 +3,9 @@ title: Auction Addon
 description: Enable an offers (bidding) system for listings, allowing buyers to submit bids and listing owners to accept offers.
 sidebar:
   order: 6
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/auction-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/booking.mdx
+++ b/src/content/docs/listdom/addons/booking.mdx
@@ -3,6 +3,9 @@ title: Booking Addon
 description: Accept and manage booking requests on listings (with date selection, availability management, and optional payments for reservations).
 sidebar:
   order: 7
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/booking-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/connect.mdx
+++ b/src/content/docs/listdom/addons/connect.mdx
@@ -3,6 +3,9 @@ title: Connect Addon
 description: Facilitate connections between users and listing owners through inquiries and direct communication tools.
 sidebar:
   order: 12
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/connect-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/elementor.mdx
+++ b/src/content/docs/listdom/addons/elementor.mdx
@@ -3,6 +3,9 @@ title: Elementor Addon
 description: Full Elementor integration for Listdom - design single listing pages, listing cards, and map info windows visually with Elementor.
 sidebar:
   order: 15
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/elementor-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/favorite.mdx
+++ b/src/content/docs/listdom/addons/favorite.mdx
@@ -3,6 +3,9 @@ title: Favorite Addon
 description: Allow users to save listings as favorites, view their saved listings, and display favorite counts.
 sidebar:
   order: 17
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/favorite-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/franchise.mdx
+++ b/src/content/docs/listdom/addons/franchise.mdx
@@ -3,6 +3,9 @@ title: Franchise Addon
 description: Create parent-child relationships between listings, ideal for franchises or multi-location businesses.
 sidebar:
   order: 18
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/franchise-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/jobs.mdx
+++ b/src/content/docs/listdom/addons/jobs.mdx
@@ -3,6 +3,9 @@ title: Jobs Addon
 description: Turn listings into job posts with application forms, resume uploads, and manage applications in the dashboard.
 sidebar:
   order: 19
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/jobs-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/kml.mdx
+++ b/src/content/docs/listdom/addons/kml.mdx
@@ -3,6 +3,9 @@ title: KML Addon
 description: Overlay KML/GPX map layers on Listdom maps, define custom map regions and paths for your directory.
 sidebar:
   order: 20
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/kml-addon/
 ---
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';
 

--- a/src/content/docs/listdom/addons/multiple-categories.mdx
+++ b/src/content/docs/listdom/addons/multiple-categories.mdx
@@ -4,6 +4,9 @@ description: Allows each listing to be assigned to multiple categories instead o
 sidebar:
   label: Multiple Categories
   order: 23
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/multiple-categories-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/pro.mdx
+++ b/src/content/docs/listdom/addons/pro.mdx
@@ -4,6 +4,9 @@ description: Unlocks premium features including front-end submissions, user dash
 sidebar:
   label: Listdom Pro
   order: 25
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/pro-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/rank.mdx
+++ b/src/content/docs/listdom/addons/rank.mdx
@@ -3,6 +3,9 @@ title: Rank Addon
 description: Automatically calculates a 'rank score' for listings based on various factors, enabling sorting and filtering of listings by rank.
 sidebar:
   order: 26
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/rank-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/listdom/addons/reviews.mdx
+++ b/src/content/docs/listdom/addons/reviews.mdx
@@ -3,6 +3,9 @@ title: Reviews Addon
 description: Enables visitors to rate and review listings, with an integrated review management system and customizable review settings.
 sidebar:
   order: 27
+header_button:
+  label: View Demo
+  url: https://demo.webilia.com/listdom/reviews-addon/
 ---
 
 import { Aside, Steps, Badge, Card, CardGrid } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary
- link Listdom addon docs to their demos via `header_button`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b8685f80088331920a1e2a7262e847